### PR TITLE
Add a proper enqueue_startall interface for all backends

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,7 +23,7 @@ BraceWrapping:
   AfterEnum: true
   AfterFunction: true
   AfterNamespace: true
-  AfterStruct: false
+  AfterStruct: true
   AfterUnion: true
   BeforeCatch: true
   BeforeElse: true

--- a/cmake/FindLibFabric.cmake
+++ b/cmake/FindLibFabric.cmake
@@ -5,7 +5,7 @@
 #  LIBFABRIC_LIBRARY     - The libraries needed to use LibFabric
 
 # searhc prefix path
-set(LIBFABRIC_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE STRING "Help cmake to find LibFabric library (https://github.com/ofiwg/libfabric).")
+set(LIBFABRIC_PREFIX "${CMAKE_PREFIX_PATH}" CACHE STRING "Help cmake to find LibFabric library (https://github.com/ofiwg/libfabric).")
 
 # check include
 find_path(LIBFABRIC_INCLUDE_DIR rdma/fabric.h

--- a/source/bindings/MPIX_Enqueue_startall.cc
+++ b/source/bindings/MPIX_Enqueue_startall.cc
@@ -1,16 +1,20 @@
-#include "abstract/request.hpp"
-#include "stream-triggering.h"
+#include "abstract/queue.hpp"
+#include "helpers.hpp"
 
 extern "C" {
 
 int MPIS_Enqueue_startall(MPIS_Queue queue, int len, MPIS_Request requests[])
 {
+    Queue*                                the_queue = (Queue*)(queue);
+    std::vector<std::shared_ptr<Request>> all_requests(len);
+
     for (int i = 0; i < len; ++i)
     {
-        int err_code = MPIS_Enqueue_start(queue, requests[i]);
-        if (MPIS_SUCCESS != err_code)
-            return err_code;
+        all_requests[i] = convert_request(requests[i]);
     }
+
+    the_queue->enqueue_startall(all_requests);
+
     return MPIS_SUCCESS;
 }
 }

--- a/source/core/include/abstract/bundle.hpp
+++ b/source/core/include/abstract/bundle.hpp
@@ -1,0 +1,56 @@
+#ifndef ST_ABSTRACT_BUNDLE
+#define ST_ABSTRACT_BUNDLE
+
+#include <vector>
+
+#include "entry.hpp"
+
+namespace Communication
+{
+class Bundle
+{
+public:
+    // No fancy constructor
+    Bundle() {};
+
+    void add_to_bundle(QueueEntry& request)
+    {
+        items.push_back(request);
+    }
+
+    void progress_serial()
+    {
+        // Start and progress operations one at a time
+        for (QueueEntry& req : items)
+        {
+            req.start_host();
+            while (!req.done())
+            {
+                // Do nothing
+            }
+        }
+    }
+    void progress_all()
+    {
+        // Start all actions
+        for (QueueEntry& req : items)
+        {
+            req.start_host();
+        }
+
+        // Wait for "starts" to complete:
+        for (QueueEntry& req : items)
+        {
+            while (!req.done())
+            {
+                // Do nothing
+            }
+        }
+    }
+
+private:
+    std::vector<std::reference_wrapper<QueueEntry>> items;
+};
+}  // namespace Communication
+
+#endif

--- a/source/core/include/abstract/match.hpp
+++ b/source/core/include/abstract/match.hpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 
+#include "misc/print.hpp"
 #include "safety/mpi.hpp"
 
 namespace Communication

--- a/source/core/include/abstract/queue.hpp
+++ b/source/core/include/abstract/queue.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 
+#include "match.hpp"
 #include "request.hpp"
 
 using namespace Communication;
@@ -21,7 +22,15 @@ public:
 
     virtual void host_wait() = 0;
 
-    virtual void match(std::shared_ptr<Request> qe) = 0;
+    virtual void match(std::shared_ptr<Request> request)
+    {
+        if (Operation::BARRIER != request->operation)
+        {
+            // Normal matching
+            Communication::BlankMatch::match(request->peer);
+        }
+        request->toggle_match();
+    };
 
     operator uintptr_t() const
     {

--- a/source/core/include/abstract/queue.hpp
+++ b/source/core/include/abstract/queue.hpp
@@ -6,7 +6,6 @@
 #include <memory>
 #include <vector>
 
-#include "match.hpp"
 #include "request.hpp"
 
 using namespace Communication;
@@ -23,15 +22,7 @@ public:
 
     virtual void host_wait() = 0;
 
-    virtual void match(std::shared_ptr<Request> request)
-    {
-        if (Operation::BARRIER != request->operation)
-        {
-            // Normal matching
-            Communication::BlankMatch::match(request->peer);
-        }
-        request->toggle_match();
-    };
+    virtual void match(std::shared_ptr<Request> request);
 
     operator uintptr_t() const
     {

--- a/source/core/include/abstract/queue.hpp
+++ b/source/core/include/abstract/queue.hpp
@@ -16,9 +16,10 @@ class Queue
 public:
     virtual ~Queue() = default;
 
-    virtual void enqueue_operation(std::shared_ptr<Request> qe) = 0;
-
-    virtual void enqueue_waitall() = 0;
+    virtual void enqueue_operation(std::shared_ptr<Request> req) = 0;
+    virtual void enqueue_startall(
+        std::vector<std::shared_ptr<Request>> reqs) = 0;
+    virtual void enqueue_waitall()                  = 0;
 
     virtual void host_wait() = 0;
 

--- a/source/core/include/queues/CudaQueue.hpp
+++ b/source/core/include/queues/CudaQueue.hpp
@@ -38,7 +38,8 @@ public:
     CudaQueue(cudaStream_t*);
     ~CudaQueue();
 
-    void enqueue_operation(std::shared_ptr<Request> qe) override;
+    void enqueue_operation(std::shared_ptr<Request> req) override;
+    void enqueue_startall(std::vector<std::shared_ptr<Request>> reqs) override;
     void enqueue_waitall() override;
     void host_wait() override;
 

--- a/source/core/include/queues/CudaQueue.hpp
+++ b/source/core/include/queues/CudaQueue.hpp
@@ -41,7 +41,6 @@ public:
     void enqueue_operation(std::shared_ptr<Request> qe) override;
     void enqueue_waitall() override;
     void host_wait() override;
-    void match(std::shared_ptr<Request> qe) override;
 
 protected:
     cudaStream_t* my_stream;

--- a/source/core/include/queues/HIPQueue.hpp
+++ b/source/core/include/queues/HIPQueue.hpp
@@ -4,12 +4,13 @@
 #include <hip/hip_runtime.h>
 
 #include <atomic>
+#include <map>
 #include <mutex>
 #include <queue>
 #include <thread>
 
-#include "abstract/queue.hpp"
 #include "abstract/entry.hpp"
+#include "abstract/queue.hpp"
 
 class HIPQueueEntry : public QueueEntry
 {
@@ -17,17 +18,14 @@ public:
     HIPQueueEntry(std::shared_ptr<Request> qe);
     ~HIPQueueEntry();
 
-    void start() override;
+    void start_host() override;
+    void start_gpu(void *) override;
+    void wait_gpu(void *) override;
     bool done() override;
 
-    void launch_wait_kernel(hipStream_t);
-    void launch_start_kernel(hipStream_t);
-
 protected:
-    std::shared_ptr<Request> my_request;
-    MPI_Request              mpi_request;
-    int64_t*                 start_location;
-    int64_t*                 wait_location;
+    int64_t* start_location;
+    int64_t* wait_location;
 
     void* start_dev;
     void* wait_dev;
@@ -36,7 +34,7 @@ protected:
 class HIPQueue : public Queue
 {
 public:
-    HIPQueue(hipStream_t *);
+    HIPQueue(hipStream_t*);
     ~HIPQueue();
 
     void enqueue_operation(std::shared_ptr<Request> qe) override;
@@ -51,12 +49,13 @@ protected:
     bool        shutdown = false;
 
     std::mutex       queue_guard;
-    std::atomic<int> start_cntr;
     std::atomic<int> wait_cntr;
 
-    std::vector<HIPQueueEntry*> entries;
-    std::vector<HIPQueueEntry*> s_ongoing;
-    std::queue<HIPQueueEntry*>  w_ongoing;
+    std::vector<std::reference_wrapper<QueueEntry>> entries;
+    std::vector<std::reference_wrapper<QueueEntry>> s_ongoing;
+    std::queue<std::reference_wrapper<QueueEntry>>  w_ongoing;
+
+    std::map<size_t, HIPQueueEntry> request_cache;
 
     void progress();
 };

--- a/source/core/include/queues/HIPQueue.hpp
+++ b/source/core/include/queues/HIPQueue.hpp
@@ -19,8 +19,8 @@ public:
     ~HIPQueueEntry();
 
     void start_host() override;
-    void start_gpu(void *) override;
-    void wait_gpu(void *) override;
+    void start_gpu(void*) override;
+    void wait_gpu(void*) override;
     bool done() override;
 
 protected:
@@ -37,7 +37,8 @@ public:
     HIPQueue(hipStream_t*);
     ~HIPQueue();
 
-    void enqueue_operation(std::shared_ptr<Request> qe) override;
+    void enqueue_operation(std::shared_ptr<Request> req) override;
+    void enqueue_startall(std::vector<std::shared_ptr<Request>> reqs) override;
     void enqueue_waitall() override;
     void host_wait() override;
 

--- a/source/core/include/queues/HIPQueue.hpp
+++ b/source/core/include/queues/HIPQueue.hpp
@@ -40,7 +40,6 @@ public:
     void enqueue_operation(std::shared_ptr<Request> qe) override;
     void enqueue_waitall() override;
     void host_wait() override;
-    void match(std::shared_ptr<Request> qe) override;
 
 protected:
     hipStream_t* my_stream;

--- a/source/core/include/queues/ThreadQueue.hpp
+++ b/source/core/include/queues/ThreadQueue.hpp
@@ -57,13 +57,6 @@ public:
         }
     }
 
-    void match(std::shared_ptr<Request> request) override
-    {
-        // Normal matching
-        Communication::BlankMatch::match(request->peer);
-        request->toggle_match();
-    }
-
 protected:
     // Thread control variables
     std::atomic<int> busy;

--- a/source/core/include/queues/ThreadQueue.hpp
+++ b/source/core/include/queues/ThreadQueue.hpp
@@ -8,6 +8,7 @@
 #include <thread>
 #include <tuple>
 
+#include "abstract/bundle.hpp"
 #include "abstract/entry.hpp"
 #include "abstract/match.hpp"
 #include "abstract/queue.hpp"
@@ -28,8 +29,7 @@ public:
 
     void enqueue_operation(UserRequest request) override
     {
-        std::scoped_lock<std::mutex> incoming_lock(queue_guard);
-        size_t                       request_id = request->getID();
+        size_t request_id = request->getID();
         if (!request_cache.contains(request_id))
         {
             // Also converts to InternalRequest
@@ -60,56 +60,11 @@ public:
     void match(std::shared_ptr<Request> request) override
     {
         // Normal matching
-        Communication::BlankMatch();
+        Communication::BlankMatch::match(request->peer);
         request->toggle_match();
     }
 
 protected:
-    class Bundle
-    {
-    public:
-        // No fancy constructor
-        Bundle() {};
-
-        void add_to_bundle(InternalRequest& request)
-        {
-            items.push_back(request);
-        }
-
-        void progress_serial()
-        {
-            // Start and progress operations one at a time
-            for (InternalRequest& req : items)
-            {
-                req.start();
-                while (!req.done())
-                {
-                    // Do nothing
-                }
-            }
-        }
-        void progress_all()
-        {
-            // Start all actions
-            for (InternalRequest& req : items)
-            {
-                req.start();
-            }
-
-            // Wait for "starts" to complete:
-            for (InternalRequest& req : items)
-            {
-                while (!req.done())
-                {
-                    // Do nothing
-                }
-            }
-        }
-
-    private:
-        std::vector<std::reference_wrapper<InternalRequest>> items;
-    };
-
     // Thread control variables
     std::atomic<int> busy;
     std::thread      thr;

--- a/source/core/include/queues/ThreadQueue.hpp
+++ b/source/core/include/queues/ThreadQueue.hpp
@@ -38,6 +38,14 @@ public:
         entries.add_to_bundle(request_cache.at(request_id));
     }
 
+    void enqueue_startall(std::vector<UserRequest> requests) override
+    {
+        for(auto& req: requests)
+        {
+            enqueue_operation(req);
+        }
+    }
+
     void enqueue_waitall() override
     {
         std::scoped_lock<std::mutex> incoming_lock(queue_guard);

--- a/source/core/source/CMakeLists.txt
+++ b/source/core/source/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(abstract)
 add_subdirectory(queues)

--- a/source/core/source/abstract/CMakeLists.txt
+++ b/source/core/source/abstract/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(stream-triggering
+	PRIVATE
+		"${CMAKE_CURRENT_SOURCE_DIR}/queue.cpp"
+)

--- a/source/core/source/abstract/queue.cpp
+++ b/source/core/source/abstract/queue.cpp
@@ -1,0 +1,18 @@
+#include "abstract/queue.hpp"
+
+#include "abstract/match.hpp"
+
+/* Done here so that CUDAQueue doesn't see the match header, as that a
+ * feature from more recent C++ that CUDA compilers don't seem to handle in
+ * cuda file (static_assert(false) is not a compile failure when using
+ * templates)
+ */
+void Queue::match(std::shared_ptr<Request> request)
+{
+    if (Operation::BARRIER != request->operation)
+    {
+        // Normal matching
+        Communication::BlankMatch::match(request->peer);
+    }
+    request->toggle_match();
+}

--- a/source/core/source/queues/CudaQueue.cpp
+++ b/source/core/source/queues/CudaQueue.cpp
@@ -20,3 +20,11 @@ void CudaQueue::enqueue_operation(std::shared_ptr<Request> request)
     std::scoped_lock<std::mutex> incoming_lock(queue_guard);
     s_ongoing.push_back(cqe);
 }
+
+void CudaQueue::enqueue_startall(std::vector<std::shared_ptr<Request>> reqs)
+{
+    for(auto& req: reqs)
+    {
+        enqueue_operation(req);
+    }
+}

--- a/source/core/source/queues/CudaQueue.cpp
+++ b/source/core/source/queues/CudaQueue.cpp
@@ -2,16 +2,6 @@
 
 #include "abstract/match.hpp"
 
-void CudaQueue::match(std::shared_ptr<Request> request)
-{
-    if (Operation::BARRIER != request->operation)
-    {
-        // Normal matching
-        Communication::BlankMatch::match(request->peer);
-    }
-    request->toggle_match();
-}
-
 void CudaQueue::enqueue_operation(std::shared_ptr<Request> request)
 {
     if (wait_cntr.load() > 0)

--- a/source/core/source/queues/CudaQueue.cpp
+++ b/source/core/source/queues/CudaQueue.cpp
@@ -4,7 +4,29 @@
 
 void CudaQueue::match(std::shared_ptr<Request> request)
 {
-    // Normal matching
-    Communication::BlankMatch::match(request->peer);
+    if (Operation::BARRIER != request->operation)
+    {
+        // Normal matching
+        Communication::BlankMatch::match(request->peer);
+    }
     request->toggle_match();
+}
+
+void CudaQueue::enqueue_operation(std::shared_ptr<Request> request)
+{
+    if (wait_cntr.load() > 0)
+        Print::out("WARNING!");
+
+    size_t request_id = request->getID();
+    if (!request_cache.contains(request_id))
+    {
+        request_cache.emplace(request_id, request);
+    }
+
+    CudaQueueEntry& cqe = request_cache.at(request_id);
+    cqe.start_gpu(my_stream);
+
+    entries.push_back(cqe);
+    std::scoped_lock<std::mutex> incoming_lock(queue_guard);
+    s_ongoing.push_back(cqe);
 }

--- a/source/core/source/queues/CudaQueue.cpp
+++ b/source/core/source/queues/CudaQueue.cpp
@@ -5,6 +5,6 @@
 void CudaQueue::match(std::shared_ptr<Request> request)
 {
     // Normal matching
-    Communication::BlankMatch();
+    Communication::BlankMatch::match(request->peer);
     request->toggle_match();
 }

--- a/source/core/source/queues/HIPQueue.cc
+++ b/source/core/source/queues/HIPQueue.cc
@@ -154,7 +154,10 @@ void HIPQueue::host_wait()
 
 void HIPQueue::match(std::shared_ptr<Request> request)
 {
-    // Normal matching
-    Communication::BlankMatch::match(request->peer);
+    if (Operation::BARRIER != request->operation)
+    {
+        // Normal matching
+        Communication::BlankMatch::match(request->peer);
+    }
     request->toggle_match();
 }

--- a/source/core/source/queues/HIPQueue.cc
+++ b/source/core/source/queues/HIPQueue.cc
@@ -5,7 +5,8 @@
 #include "safety/hip.hpp"
 #include "safety/mpi.hpp"
 
-HIPQueueEntry::HIPQueueEntry(std::shared_ptr<Request> req) : QueueEntry(req)
+HIPQueueEntry::HIPQueueEntry(std::shared_ptr<Request> req)
+    : QueueEntry(req)
 {
     force_hip(hipHostMalloc((void**)&start_location, sizeof(int64_t), 0));
     *start_location = 0;
@@ -21,14 +22,14 @@ HIPQueueEntry::~HIPQueueEntry()
     check_hip(hipHostFree(wait_location));
 }
 
-void HIPQueueEntry::start()
+void HIPQueueEntry::start_host()
 {
-    while ((*start_location) != 1)
+    while ((*start_location) != threshold)
     {
         std::this_thread::yield();
     }
     // Call parent method to launch MPI stuff
-    QueueEntry::start();
+    QueueEntry::start_host();
 }
 
 bool HIPQueueEntry::done()
@@ -37,19 +38,21 @@ bool HIPQueueEntry::done()
     bool value = QueueEntry::done();
     if (value)
     {
-        (*wait_location) = 1;
+        (*wait_location) = threshold;
     }
     return value;
 }
 
-void HIPQueueEntry::launch_start_kernel(hipStream_t the_stream)
+void HIPQueueEntry::start_gpu(void* the_stream)
 {
-    force_hip(hipStreamWriteValue64(the_stream, start_dev, 1, 0));
+    force_hip(hipStreamWriteValue64(*((hipStream_t*)the_stream), start_dev,
+                                    threshold, 0));
 }
 
-void HIPQueueEntry::launch_wait_kernel(hipStream_t the_stream)
+void HIPQueueEntry::wait_gpu(void* the_stream)
 {
-    force_hip(hipStreamWaitValue64(the_stream, wait_dev, 1, 0));
+    force_hip(hipStreamWaitValue64(*((hipStream_t*)the_stream), wait_dev,
+                                   threshold, 0));
 }
 
 HIPQueue::HIPQueue(hipStream_t* stream)
@@ -68,15 +71,14 @@ void HIPQueue::progress()
 {
     while (!shutdown)
     {
-        while (start_cntr.load() > 0 || wait_cntr.load() > 0)
+        while (s_ongoing.size() > 0 || wait_cntr.load() > 0)
         {
-            if(start_cntr.load() > 0)
+            if (s_ongoing.size() > 0)
             {
                 std::scoped_lock<std::mutex> incoming_lock(queue_guard);
-                for (HIPQueueEntry* entry : s_ongoing)
+                for (QueueEntry& entry : s_ongoing)
                 {
-                    entry->start();
-                    start_cntr--;
+                    entry.start_host();
                     w_ongoing.push(entry);
                 }
                 s_ongoing.clear();
@@ -84,8 +86,8 @@ void HIPQueue::progress()
 
             for (size_t i = 0; i < w_ongoing.size(); ++i)
             {
-                HIPQueueEntry* entry = w_ongoing.front();
-                if (entry->done())
+                QueueEntry& entry = w_ongoing.front();
+                if (entry.done())
                 {
                     wait_cntr--;
                     w_ongoing.pop();
@@ -104,30 +106,35 @@ void HIPQueue::progress()
     }
 }
 
-void HIPQueue::enqueue_operation(std::shared_ptr<Request> qe)
+void HIPQueue::enqueue_operation(std::shared_ptr<Request> request)
 {
     if (wait_cntr.load() > 0)
         Print::out("WARNING!");
 
-    HIPQueueEntry* cqe = new HIPQueueEntry(qe);
-    cqe->launch_start_kernel(*my_stream);
-    start_cntr++;
-    entries.push_back(cqe);
+    size_t request_id = request->getID();
+    if (!request_cache.contains(request_id))
+    {
+        request_cache.emplace(request_id, request);
+    }
 
+    HIPQueueEntry& cqe = request_cache.at(request_id);
+    cqe.start_gpu(my_stream);
+
+    entries.push_back(cqe);
     std::scoped_lock<std::mutex> incoming_lock(queue_guard);
     s_ongoing.push_back(cqe);
 }
 
 void HIPQueue::enqueue_waitall()
 {
-    while (start_cntr.load())
+    while (s_ongoing.size())
     {
         // Do nothing
     }
 
-    for (HIPQueueEntry* entry : entries)
+    for (QueueEntry& entry : entries)
     {
-        entry->launch_wait_kernel(*my_stream);
+        entry.wait_gpu(my_stream);
         wait_cntr++;
         while (wait_cntr.load())
         {
@@ -139,7 +146,7 @@ void HIPQueue::enqueue_waitall()
 
 void HIPQueue::host_wait()
 {
-    while (start_cntr.load() || wait_cntr.load())
+    while (s_ongoing.size() || wait_cntr.load())
     {
         // Do nothing.
     }
@@ -148,6 +155,6 @@ void HIPQueue::host_wait()
 void HIPQueue::match(std::shared_ptr<Request> request)
 {
     // Normal matching
-    Communication::BlankMatch();
+    Communication::BlankMatch::match(request->peer);
     request->toggle_match();
 }

--- a/source/core/source/queues/HIPQueue.cc
+++ b/source/core/source/queues/HIPQueue.cc
@@ -125,6 +125,14 @@ void HIPQueue::enqueue_operation(std::shared_ptr<Request> request)
     s_ongoing.push_back(cqe);
 }
 
+void HIPQueue::enqueue_startall(std::vector<std::shared_ptr<Request>> reqs)
+{
+    for(auto& req: reqs)
+    {
+        enqueue_operation(req);
+    }
+}
+
 void HIPQueue::enqueue_waitall()
 {
     while (s_ongoing.size())

--- a/source/core/source/queues/HIPQueue.cc
+++ b/source/core/source/queues/HIPQueue.cc
@@ -151,13 +151,3 @@ void HIPQueue::host_wait()
         // Do nothing.
     }
 }
-
-void HIPQueue::match(std::shared_ptr<Request> request)
-{
-    if (Operation::BARRIER != request->operation)
-    {
-        // Normal matching
-        Communication::BlankMatch::match(request->peer);
-    }
-    request->toggle_match();
-}

--- a/tests/benchmark/common.hpp
+++ b/tests/benchmark/common.hpp
@@ -54,7 +54,7 @@ void allocate_gpu_memory(void** location, size_t size)
 
 void device_sync()
 {
-    check_hip(hipDeviceSynchronize());
+    check_gpu(hipDeviceSynchronize());
 }
 
 #elif NEED_CUDA

--- a/tests/benchmark/pingpong.cpp
+++ b/tests/benchmark/pingpong.cpp
@@ -99,7 +99,7 @@ int main(int argc, char* argv[])
             pack_buffer<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
                 (int*)send_buf, BUFFER_SIZE, i);
 #ifdef THREAD_BACKEND
-            check_hip(hipDeviceSynchronize());
+            check_gpu(hipDeviceSynchronize());
 #endif
             MPIS_Enqueue_startall(my_queue, 2, my_reqs);
             MPIS_Enqueue_waitall(my_queue);
@@ -118,7 +118,7 @@ int main(int argc, char* argv[])
             pack_buffer2<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
                 (int*)send_buf, (int*)recv_buf, BUFFER_SIZE);
 #ifdef THREAD_BACKEND
-            check_hip(hipDeviceSynchronize());
+            check_gpu(hipDeviceSynchronize());
 #endif
             MPIS_Enqueue_start(my_queue, my_reqs[SEND_REQ]);
             MPIS_Enqueue_waitall(my_queue);

--- a/tests/benchmark/pingpong_mpi.cpp
+++ b/tests/benchmark/pingpong_mpi.cpp
@@ -23,15 +23,10 @@ int main(int argc, char* argv[])
 
     void* send_buf = nullptr;
     void* recv_buf = nullptr;
-#ifndef FINE_GRAINED_TEST
-    force_hip(hipMalloc(&send_buf, sizeof(int) * BUFFER_SIZE));
-    force_hip(hipMalloc(&recv_buf, sizeof(int) * BUFFER_SIZE));
-#else
     force_hip(hipExtMallocWithFlags(&send_buf, sizeof(int) * BUFFER_SIZE,
                                     hipDeviceMallocFinegrained));
     force_hip(hipExtMallocWithFlags(&recv_buf, sizeof(int) * BUFFER_SIZE,
                                     hipDeviceMallocFinegrained));
-#endif
 
     init_buffers<<<NUM_BLOCKS, BLOCK_SIZE>>>((int*)send_buf, (int*)recv_buf,
                                              BUFFER_SIZE);
@@ -40,97 +35,53 @@ int main(int argc, char* argv[])
     hipStream_t my_stream;
     check_hip(hipStreamCreateWithFlags(&my_stream, hipStreamNonBlocking));
 
-    // Make queue
-    MPIS_Queue my_queue;
-#if defined(HIP_BACKEND)
-    MPIS_Queue_init(&my_queue, GPU_MEM_OPS, &my_stream);
-#elif defined(CXI_BACKEND)
-    MPIS_Queue_init(&my_queue, CXI, &my_stream);
-#elif defined(THREAD_BACKEND)
-    MPIS_Queue_init(&my_queue, THREAD, &my_stream);
-#endif
-
-    // Info hint
-    MPI_Info mem_info;
-    MPI_Info_create(&mem_info);
-#ifndef FINE_GRAINED_TEST
-    MPI_Info_set(mem_info, "MPIS_GPU_MEM_TYPE", "COARSE");
-#else
-    MPI_Info_set(mem_info, "MPIS_GPU_MEM_TYPE", "FINE");
-#endif
-
 #define SEND_REQ (rank ^ 1)
 #define RECV_REQ (rank & 1)
 
     // Make requests
-    MPIS_Request my_reqs[2];
-    // MPIS_Request queue_reqs[2]; TODO
+    MPI_Request my_reqs[2];
     if (0 == rank % 2)
     {
-        MPIS_Send_init(send_buf, BUFFER_SIZE, MPI_INT, 1, 0, MPI_COMM_WORLD,
-                       mem_info, &my_reqs[SEND_REQ]);
-        MPIS_Recv_init(recv_buf, BUFFER_SIZE, MPI_INT, 1, 0, MPI_COMM_WORLD,
-                       mem_info, &my_reqs[RECV_REQ]);
+        MPI_Send_init(send_buf, BUFFER_SIZE, MPI_INT, 1, 0, MPI_COMM_WORLD,
+                      &my_reqs[SEND_REQ]);
+        MPI_Recv_init(recv_buf, BUFFER_SIZE, MPI_INT, 1, 0, MPI_COMM_WORLD,
+                      &my_reqs[RECV_REQ]);
     }
     else
     {
-        MPIS_Recv_init(recv_buf, BUFFER_SIZE, MPI_INT, 0, 0, MPI_COMM_WORLD,
-                       mem_info, &my_reqs[RECV_REQ]);
-        MPIS_Send_init(recv_buf, BUFFER_SIZE, MPI_INT, 0, 0, MPI_COMM_WORLD,
-                       mem_info, &my_reqs[SEND_REQ]);
+        MPI_Recv_init(recv_buf, BUFFER_SIZE, MPI_INT, 0, 0, MPI_COMM_WORLD,
+                      &my_reqs[RECV_REQ]);
+        MPI_Send_init(recv_buf, BUFFER_SIZE, MPI_INT, 0, 0, MPI_COMM_WORLD,
+                      &my_reqs[SEND_REQ]);
     }
-
-    MPIS_Request barrier_req;
-    MPIS_Barrier_init(MPI_COMM_WORLD, MPI_INFO_NULL, &barrier_req);
-
-    MPIS_Match(my_reqs[0]);
-    MPIS_Match(my_reqs[1]);
-    MPIS_Match(barrier_req);
 
     double start = MPI_Wtime();
     for (int i = 0; i < num_iters; i++)
     {
         if (0 == rank)
         {
-#ifdef THREAD_BACKEND
-            MPIS_Queue_wait(my_queue);
-#endif
             // Ping side
             pack_buffer<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
                 (int*)send_buf, BUFFER_SIZE, i);
-#ifdef THREAD_BACKEND
             check_hip(hipDeviceSynchronize());
-#endif
-            MPIS_Enqueue_startall(my_queue, 2, my_reqs);
-            MPIS_Enqueue_waitall(my_queue);
+            MPI_Startall(2, my_reqs);
+            MPI_Waitall(2, my_reqs, MPI_STATUSES_IGNORE);
             // print_buffer<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
             //     (int*)recv_buf, BUFFER_SIZE, i, rank);
         }
         else
         {
-            MPIS_Enqueue_start(my_queue, my_reqs[RECV_REQ]);
-            MPIS_Enqueue_waitall(my_queue);
-#ifdef THREAD_BACKEND
-            MPIS_Queue_wait(my_queue);
-#endif
+            MPI_Start(&my_reqs[RECV_REQ]);
+            MPI_Wait(&my_reqs[RECV_REQ], MPI_STATUS_IGNORE);
             // print_buffer<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
             //     (int*)recv_buf, BUFFER_SIZE, i, rank);
             pack_buffer2<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
                 (int*)send_buf, (int*)recv_buf, BUFFER_SIZE);
-#ifdef THREAD_BACKEND
             check_hip(hipDeviceSynchronize());
-#endif
-            MPIS_Enqueue_start(my_queue, my_reqs[SEND_REQ]);
-            MPIS_Enqueue_waitall(my_queue);
+            MPI_Start(&my_reqs[SEND_REQ]);
+            MPI_Wait(&my_reqs[SEND_REQ], MPI_STATUS_IGNORE);
         }
-
-        MPIS_Enqueue_start(my_queue, barrier_req);
     }
-
-    // std::cout << rank << " at final wait!" << std::endl;
-
-    MPIS_Enqueue_waitall(my_queue);
-    MPIS_Queue_wait(my_queue);
     double end = MPI_Wtime();
 
     // Final check
@@ -140,12 +91,8 @@ int main(int argc, char* argv[])
     check_hip(hipDeviceSynchronize());
 
     // Cleanup
-    MPIS_Request_freeall(2, my_reqs);
-    MPIS_Request_free(&barrier_req);
-
-    MPI_Info_free(&mem_info);
-
-    MPIS_Queue_free(&my_queue);
+    MPI_Request_free(&my_reqs[SEND_REQ]);
+    MPI_Request_free(&my_reqs[RECV_REQ]);
 
     std::cout << rank << " is done: " << end - start << std::endl;
 

--- a/tests/benchmark/raw_pingpong.cpp
+++ b/tests/benchmark/raw_pingpong.cpp
@@ -1,0 +1,183 @@
+#include "common.hpp"
+
+int main(int argc, char* argv[])
+{
+    int mode;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mode);
+
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    // I want "two params"
+    check_param_size(&argc, 2,
+                     "<program> <number of iterations> <buffer size>");
+
+    // Input parameters
+    int num_iters   = 0;
+    int BUFFER_SIZE = 0;
+    read_iter_buffer_input(&argv, &num_iters, &BUFFER_SIZE);
+
+    // Make Buffers
+    int BLOCK_SIZE = 128;
+    int NUM_BLOCKS = (BUFFER_SIZE + BLOCK_SIZE - 1) / BLOCK_SIZE;
+
+    void* send_buf = nullptr;
+    void* recv_buf = nullptr;
+    allocate_gpu_memory(&send_buf, sizeof(int) * BUFFER_SIZE * 2);
+    allocate_gpu_memory(&recv_buf, sizeof(int) * BUFFER_SIZE * 2);
+
+    init_buffers<<<NUM_BLOCKS, BLOCK_SIZE>>>((int*)send_buf, (int*)recv_buf,
+                                             BUFFER_SIZE * 2);
+    device_sync();
+
+#if defined(NEED_HIP)
+    hipStream_t my_stream;
+    check_gpu(hipStreamCreateWithFlags(&my_stream, hipStreamNonBlocking));
+#elif defined(NEED_CUDA)
+    cudaStream_t my_stream;
+    check_gpu(cudaStreamCreateWithFlags(&my_stream, cudaStreamNonBlocking));
+#endif
+
+    // Make queue
+    MPIS_Queue my_queue;
+#if defined(HIP_BACKEND)
+    MPIS_Queue_init(&my_queue, GPU_MEM_OPS, &my_stream);
+#elif defined(CUDA_BACKEND)
+    MPIS_Queue_init(&my_queue, GPU_MEM_OPS, &my_stream);
+#elif defined(CXI_BACKEND)
+    MPIS_Queue_init(&my_queue, CXI, &my_stream);
+#elif defined(THREAD_BACKEND)
+    MPIS_Queue_init(&my_queue, THREAD, &my_stream);
+#endif
+
+    // Info hint
+    MPI_Info mem_info;
+    MPI_Info_create(&mem_info);
+#ifndef FINE_GRAINED_TEST
+    MPI_Info_set(mem_info, "MPIS_GPU_MEM_TYPE", "COARSE");
+#else
+    MPI_Info_set(mem_info, "MPIS_GPU_MEM_TYPE", "FINE");
+#endif
+
+#define SEND_REQ (rank ^ 1)
+#define RECV_REQ (rank & 1)
+
+    // Make requests
+    MPIS_Request my_reqs[2];
+    MPIS_Request my_other_reqs[2];
+    // MPIS_Request queue_reqs[2]; TODO
+    int offset = sizeof(int) * BUFFER_SIZE;
+    if (0 == rank % 2)
+    {
+        MPIS_Send_init(send_buf, BUFFER_SIZE, MPI_INT, 1, 0, MPI_COMM_WORLD,
+                       mem_info, &my_reqs[SEND_REQ]);
+        MPIS_Recv_init(recv_buf, BUFFER_SIZE, MPI_INT, 1, 0, MPI_COMM_WORLD,
+                       mem_info, &my_reqs[RECV_REQ]);
+        MPIS_Send_init((char*)send_buf + offset, BUFFER_SIZE, MPI_INT, 1, 0,
+                       MPI_COMM_WORLD, mem_info, &my_other_reqs[SEND_REQ]);
+        MPIS_Recv_init((char*)recv_buf + offset, BUFFER_SIZE, MPI_INT, 1, 0,
+                       MPI_COMM_WORLD, mem_info, &my_other_reqs[RECV_REQ]);
+    }
+    else
+    {
+        MPIS_Recv_init(recv_buf, BUFFER_SIZE, MPI_INT, 0, 0, MPI_COMM_WORLD,
+                       mem_info, &my_reqs[RECV_REQ]);
+        MPIS_Send_init(recv_buf, BUFFER_SIZE, MPI_INT, 0, 0, MPI_COMM_WORLD,
+                       mem_info, &my_reqs[SEND_REQ]);
+        MPIS_Recv_init((char*)recv_buf + offset, BUFFER_SIZE, MPI_INT, 0, 0,
+                       MPI_COMM_WORLD, mem_info, &my_other_reqs[RECV_REQ]);
+        MPIS_Send_init((char*)recv_buf + offset, BUFFER_SIZE, MPI_INT, 0, 0,
+                       MPI_COMM_WORLD, mem_info, &my_other_reqs[SEND_REQ]);
+    }
+
+    MPIS_Match(my_reqs[0]);
+    MPIS_Match(my_reqs[1]);
+    MPIS_Match(my_other_reqs[0]);
+    MPIS_Match(my_other_reqs[1]);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    void* active_send_buffer = send_buf;
+    void* active_recv_buffer = recv_buf;
+
+    void* inactive_send_buffer = (char*)send_buf + offset;
+    void* inactive_recv_buffer = (char*)recv_buf + offset;
+
+    MPIS_Request* active_request_ptr   = my_reqs;
+    MPIS_Request* inactive_request_ptr = my_other_reqs;
+
+    double start = MPI_Wtime();
+    for (int i = 0; i < num_iters; i++)
+    {
+        if (0 == rank)
+        {
+#ifdef THREAD_BACKEND
+            MPIS_Queue_wait(my_queue);
+#endif
+            // Ping side
+            pack_buffer<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
+                (int*)active_send_buffer, BUFFER_SIZE, i);
+#ifdef THREAD_BACKEND
+            check_gpu(hipDeviceSynchronize());
+#endif
+            MPIS_Enqueue_startall(my_queue, 2, active_request_ptr);
+            MPIS_Enqueue_waitall(my_queue);
+            // print_buffer<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
+            //     (int*)recv_buf, BUFFER_SIZE, i, rank);
+        }
+        else
+        {
+            MPIS_Enqueue_start(my_queue, active_request_ptr[RECV_REQ]);
+            MPIS_Enqueue_waitall(my_queue);
+#ifdef THREAD_BACKEND
+            MPIS_Queue_wait(my_queue);
+#endif
+            // print_buffer<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
+            //     (int*)recv_buf, BUFFER_SIZE, i, rank);
+            pack_buffer2<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
+                (int*)send_buf, (int*)active_recv_buffer, BUFFER_SIZE);
+#ifdef THREAD_BACKEND
+            check_gpu(hipDeviceSynchronize());
+#endif
+            MPIS_Enqueue_start(my_queue, active_request_ptr[SEND_REQ]);
+            MPIS_Enqueue_waitall(my_queue);
+        }
+
+        void* temp_send      = active_send_buffer;
+        active_send_buffer   = inactive_send_buffer;
+        inactive_send_buffer = temp_send;
+
+        void* temp_recv      = active_recv_buffer;
+        active_recv_buffer   = inactive_recv_buffer;
+        inactive_recv_buffer = temp_recv;
+
+        MPIS_Request* temp_reqs = active_request_ptr;
+        active_request_ptr      = inactive_request_ptr;
+        inactive_request_ptr    = temp_reqs;
+    }
+
+    // std::cout << rank << " at final wait!" << std::endl;
+
+    MPIS_Enqueue_waitall(my_queue);
+    MPIS_Queue_wait(my_queue);
+    double end = MPI_Wtime();
+
+    // Final check
+    device_sync();
+    print_buffer<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
+        (int*)inactive_recv_buffer, BUFFER_SIZE, num_iters - 1, rank);
+    device_sync();
+
+    // Cleanup
+    MPIS_Request_freeall(2, my_reqs);
+    MPIS_Request_freeall(2, my_other_reqs);
+
+    MPI_Info_free(&mem_info);
+
+    MPIS_Queue_free(&my_queue);
+
+    std::cout << rank << " is done: " << end - start << std::endl;
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/tests/benchmark/raw_pingpong.cpp
+++ b/tests/benchmark/raw_pingpong.cpp
@@ -121,8 +121,8 @@ int main(int argc, char* argv[])
 #endif
             MPIS_Enqueue_startall(my_queue, 2, active_request_ptr);
             MPIS_Enqueue_waitall(my_queue);
-            // print_buffer<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
-            //     (int*)recv_buf, BUFFER_SIZE, i, rank);
+            //print_buffer<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
+            //    (int*)active_recv_buffer, BUFFER_SIZE, i, rank);
         }
         else
         {
@@ -131,8 +131,8 @@ int main(int argc, char* argv[])
 #ifdef THREAD_BACKEND
             MPIS_Queue_wait(my_queue);
 #endif
-            // print_buffer<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
-            //     (int*)recv_buf, BUFFER_SIZE, i, rank);
+            //print_buffer<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
+            //     (int*)active_recv_buffer, BUFFER_SIZE, i, rank);
             pack_buffer2<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
                 (int*)send_buf, (int*)active_recv_buffer, BUFFER_SIZE);
 #ifdef THREAD_BACKEND
@@ -156,8 +156,6 @@ int main(int argc, char* argv[])
     }
 
     // std::cout << rank << " at final wait!" << std::endl;
-
-    MPIS_Enqueue_waitall(my_queue);
     MPIS_Queue_wait(my_queue);
     double end = MPI_Wtime();
 


### PR DESCRIPTION
While we've had the `MPIX_Enqueue_startall`, it was just a loop around `MPIX_Enqueue_start`. This PR moves the responsibility down to the abstract interface for the back-ends. Additionally, the CXI backend will make sure all enqueued operations are setup to fire off the same trigger. Other back-ends remain unchanged in functionality (they will just call their enqueue_start inside a loop).

Other technical changes:
- CXI backend now only ever makes one counter, even if things are enqueued one at a time
- Minor cmake and formatting tweaks
- Added a `Bundle` class since some of the back-ends where using a similar concept for grouping requests together
- Moved some default behaviors into the abstract classes
- And doing that for the Queue class messed up CUDA compiling so now there's a Queue.cpp. This allowed me to move the code nvcc hates (static_assert(false)) outside of a header that was included in a .cu file)
- Added some early benchmarks that put the current APIs to the test