### PR TITLE
Support multiple GPUs on a single node

### DIFF
--- a/source/bindings/MPI_Overrides.cc
+++ b/source/bindings/MPI_Overrides.cc
@@ -6,7 +6,6 @@ extern "C" {
 
 int MPI_Init_thread(int* argc, char*** argv, int required, int* provided)
 {
-    init_device();
     int error_code = PMPI_Init_thread(argc, argv, required, provided);
     init_debugs();
     return error_code;
@@ -14,7 +13,6 @@ int MPI_Init_thread(int* argc, char*** argv, int required, int* provided)
 
 int MPI_Init(int* argc, char*** argv)
 {
-    init_device();
     int error_code = PMPI_Init(argc, argv);
     init_debugs();
     return error_code;
@@ -22,7 +20,6 @@ int MPI_Init(int* argc, char*** argv)
 
 void MPIS_Hello_world()
 {
-    init_device();
     init_debugs();
 }
 }

--- a/source/bindings/helpers.hpp
+++ b/source/bindings/helpers.hpp
@@ -35,29 +35,38 @@ struct MPISException : public std::runtime_error
     int code;
 };
 
+static inline void print_device_info()
+{
+    int device = -1;
+    int count = -1;
+    force_hip(hipGetDevice(&device));
+    force_hip(hipGetDeviceCount(&count));
+    Print::out("Current Device:", device, count);
+
+    for(int i = 0; i < count; i++)
+    {
+        int pci_bus_id = -1;
+        int pci_device_id = -1;
+        int pci_domain_id = -1;
+        force_hip(hipDeviceGetAttribute(&pci_bus_id, hipDeviceAttributePciBusId, i)); 
+        force_hip(hipDeviceGetAttribute(&pci_device_id, hipDeviceAttributePciDeviceId, i)); 
+        force_hip(hipDeviceGetAttribute(&pci_domain_id, hipDeviceAttributePciDomainID, i));
+        Print::out("Others:", i, pci_bus_id, pci_device_id, pci_domain_id);
+    }    
+
+}
+
 static inline void init_debugs()
 {
-    // #ifndef NDEBUG
+
     //  Setup printing rank
     int rank = -1;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     Print::initialize_rank(rank);
     Print::out("Initialized");
-    // #endif
-}
-
-static inline void init_device()
-{
-#ifdef USE_GFX90A
-    force_hip(hipInit(0));
-    int device = -1;
-    int count = -1;
-    force_hip(hipGetDevice(&device));
-    force_hip(hipGetDeviceCount(&count));
-    std::cout << "info: " << device << " " << count << std::endl;
-    force_hip(hipSetDevice(6));
-    Print::out("Initialized Device to 6");
-#endif
+    #ifndef NDEBUG
+    print_device_info();
+    #endif
 }
 
 // Functions for extracting C++ request from C type (if it's correct request

--- a/tests/benchmark/cxi_ring.cpp
+++ b/tests/benchmark/cxi_ring.cpp
@@ -1,0 +1,98 @@
+#include "common.hpp"
+
+int main(int argc, char* argv[])
+{
+    int mode;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mode);
+
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    int size;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    // Make HIP variables
+    int BUFFER_SIZE = 10;
+    int BLOCK_SIZE  = 128;
+    int NUM_BLOCKS  = (BUFFER_SIZE + BLOCK_SIZE - 1) / BLOCK_SIZE;
+
+    void* send_buf = nullptr;
+    void* recv_buf = nullptr;
+    allocate_gpu_memory(&send_buf, sizeof(int) * BUFFER_SIZE);
+    allocate_gpu_memory(&recv_buf, sizeof(int) * BUFFER_SIZE);
+
+    init_buffers2<<<NUM_BLOCKS, BLOCK_SIZE>>>((int*)send_buf, (int*)recv_buf, BUFFER_SIZE,
+                                              rank);
+
+    device_sync();
+#if defined(NEED_HIP)
+    hipStream_t my_stream;
+    check_gpu(hipStreamCreateWithFlags(&my_stream, hipStreamNonBlocking));
+#elif defined(NEED_CUDA)
+    cudaStream_t my_stream;
+    check_gpu(cudaStreamCreateWithFlags(&my_stream, cudaStreamNonBlocking));
+#endif
+
+    // Make queue
+    MPIS_Queue my_queue;
+#if defined(HIP_BACKEND)
+    MPIS_Queue_init(&my_queue, GPU_MEM_OPS, &my_stream);
+#elif defined(CUDA_BACKEND)
+    MPIS_Queue_init(&my_queue, GPU_MEM_OPS, &my_stream);
+#elif defined(CXI_BACKEND)
+    MPIS_Queue_init(&my_queue, CXI, &my_stream);
+#elif defined(THREAD_BACKEND)
+    MPIS_Queue_init(&my_queue, THREAD, &my_stream);
+#endif
+
+    // Info hint
+    MPI_Info mem_info;
+    MPI_Info_create(&mem_info);
+#ifndef FINE_GRAINED_TEST
+    MPI_Info_set(mem_info, "MPIS_GPU_MEM_TYPE", "COARSE");
+#else
+    MPI_Info_set(mem_info, "MPIS_GPU_MEM_TYPE", "FINE");
+#endif
+
+    // Make requests
+    MPIS_Request my_reqs[2];
+    MPIS_Send_init(send_buf, BUFFER_SIZE, MPI_INT, (rank + 1) % size, 0, MPI_COMM_WORLD,
+                   mem_info, &my_reqs[0]);
+    MPIS_Recv_init(recv_buf, BUFFER_SIZE, MPI_INT, (rank - 1 + size) % size, 0,
+                   MPI_COMM_WORLD, mem_info, &my_reqs[1]);
+
+    MPIS_Matchall(2, my_reqs, MPI_STATUSES_IGNORE);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 0)
+    {
+        MPIS_Enqueue_startall(my_queue, 2, my_reqs);
+        MPIS_Enqueue_waitall(my_queue);
+    }
+    else
+    {
+        MPIS_Enqueue_start(my_queue, &my_reqs[1]);
+        MPIS_Enqueue_waitall(my_queue);
+        pack_buffer3<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>(
+            (int*)send_buf, (int*)recv_buf, BUFFER_SIZE);
+        MPIS_Enqueue_start(my_queue, &my_reqs[0]);
+        MPIS_Enqueue_waitall(my_queue);
+    }
+
+    MPIS_Queue_wait(my_queue);
+
+    device_sync();
+    print_buffer2<<<NUM_BLOCKS, BLOCK_SIZE, 0, my_stream>>>((int*)recv_buf, BUFFER_SIZE,
+                                                            rank);
+    device_sync();
+
+    // Cleanup
+    MPIS_Request_freeall(2, my_reqs);
+    MPI_Info_free(&mem_info);
+    MPIS_Queue_free(&my_queue);
+
+    std::cout << rank << " is done." << std::endl;
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/tests/hello_world/cxi_simple.cpp
+++ b/tests/hello_world/cxi_simple.cpp
@@ -137,12 +137,12 @@ int main()
                        mem_info, &my_reqs[SEND_REQ]);
     }
 
-    MPIS_Match(my_reqs[0]);
-    MPIS_Match(my_reqs[1]);
+    MPIS_Match(&my_reqs[0], MPI_STATUS_IGNORE);
+    MPIS_Match(&my_reqs[1], MPI_STATUS_IGNORE);
 
     if (1 == rank)
     {
-        MPIS_Enqueue_start(my_queue, my_reqs[RECV_REQ]);
+        MPIS_Enqueue_start(my_queue, &my_reqs[RECV_REQ]);
     }
     MPIS_Queue_wait(my_queue);
     MPI_Barrier(MPI_COMM_WORLD);
@@ -174,7 +174,7 @@ int main()
             }
             else
             {
-                MPIS_Enqueue_start(my_queue, my_reqs[SEND_REQ]);
+                MPIS_Enqueue_start(my_queue, &my_reqs[SEND_REQ]);
                 MPIS_Enqueue_waitall(my_queue);
             }
         }


### PR DESCRIPTION
Removes the hard-coded use of a GPU and instead either just uses the current device, or enters a special case for the MI250s where the current device needs a specific NIC. 

Adds a simple ring test for verifying that multiple GPUs works.