### PR TITLE
Added specialized communicators to help limit collisions during matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # stream-triggering
 An MPI Advance library exploring various stream triggering APIs
+
+# Available backends
+This implementation currently features four backends to use for the stream triggering APIs. The build of this library can have any number of them turned on at once, provided the proper libraries are on the system:
+- **Thread**:  `-DUSE_THREAD_BACKEND=ON` - Uses a thread to offload communication too. Note that because this cannot tie to any GPU streams, the user must *manually* sync communication with the gpu. As such, this backend is purely for testing purposes and offers no real functionality over regular MPI.
+- **HIP/CUDA**: `-DUSE_CUDA_BACKEND=ON` or `-DUSE_HIP_BACKEND=ON` - These two backends use the stream ops (`cuStreamWrite/WaitValue64` and `hipStreamWrite/WaitValue64`, respectively) to perform stream triggered communication. Note that the CUDA version may have issues running on some systems if the memory ops [are not enabled](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__MEMOP.html) (library may build, but not run.)
+- **CXI**: `-DUSE_CXI_BACKEND` - This backend currently requires HIP support on the system to run, in addition to the requirement of the CXI libfabric provider. Uses extensions from the CXI libfabric provider to offer fully GPU driven communication.
+
+
+## CXI Backend Limitations
+Currently, the CXI backend needs to do a bidirectional data exchange in the match. To avoid _most_ collisions with other user MPI messages, and other stream_triggering communication matches, a separate communicator is made for each direction of the data exchange. However, if an application creates multiple communicators with overlapping ranks, and creates stream-triggered requests in a manner similar to this:
+```c
+MPI_Comm my_comm_a; // Custom communicator with at least ranks (0,1)
+MPI_Comm my_comm_b; // Custom communicator with at least ranks (0,1)
+MPIS_Request my_reqs[4];
+
+// "rank 0"
+MPIS_Send_init(/*to rank 1*/, my_comm_a, &my_reqs[0]); // A
+MPIS_Send_init(/*to rank 1*/, my_comm_b, &my_reqs[1]); // B
+// "rank 1"
+MPIS_Recv_init(/*to rank 0*/, my_comm_b, &my_reqs[0]); // C
+MPIS_Recv_init(/*to rank 0*/, my_comm_a, &my_reqs[1]); // D
+
+MPIS_Matchall(4, my_reqs, MPI_STATUSES_IGNORE);
+
+```
+then a collision will likely still occur in the match. In this particular example, `A` will match with `C` instead of the user's desire to match `A` and `D`.

--- a/source/core/include/abstract/match.hpp
+++ b/source/core/include/abstract/match.hpp
@@ -32,43 +32,64 @@ class ProtocolMatch
 public:
     static void receiver(struct fi_rma_iov* user_buffer_details,
                          struct fi_rma_iov* completion_details, Operation* op_details,
-                         struct fi_rma_iov* cts_details, Request& req)
+                         struct fi_rma_iov* cts_details, Request& req, MPI_Comm phase_a,
+                         MPI_Comm phase_b)
     {
-        Print::out("(Receiver) Matching with:", req.peer, "and tag", req.tag);
+        int real_rank = rankLookup(req.peer, req.comm, phase_a);
+        Print::out("(Receiver) Matching with:", real_rank, "and tag", req.tag);
         MPI_Request* mpi_requests = req.get_match_requests(REQUESTS_TO_USE);
 
         Print::out("(Recv) Sending: ", user_buffer_details->addr,
                    user_buffer_details->len, user_buffer_details->key,
                    completion_details->addr, completion_details->len,
                    completion_details->key);
-        check_mpi(MPI_Isend(user_buffer_details, sizeof(fi_rma_iov), MPI_BYTE, req.peer,
-                            req.tag, req.comm, &mpi_requests[0]));
-        check_mpi(MPI_Isend(completion_details, sizeof(fi_rma_iov), MPI_BYTE, req.peer,
-                            req.tag, req.comm, &mpi_requests[1]));
-        check_mpi(MPI_Irecv(op_details, sizeof(Operation), MPI_BYTE, req.peer, req.tag,
-                            req.comm, &mpi_requests[2]));
-        check_mpi(MPI_Irecv(cts_details, sizeof(fi_rma_iov), MPI_BYTE, req.peer, req.tag,
-                            req.comm, &mpi_requests[3]));
+        check_mpi(MPI_Isend(user_buffer_details, sizeof(fi_rma_iov), MPI_BYTE, real_rank,
+                            req.tag, phase_a, &mpi_requests[0]));
+        check_mpi(MPI_Isend(completion_details, sizeof(fi_rma_iov), MPI_BYTE, real_rank,
+                            req.tag, phase_a, &mpi_requests[1]));
+        check_mpi(MPI_Irecv(op_details, sizeof(Operation), MPI_BYTE, real_rank, req.tag,
+                            phase_b, &mpi_requests[2]));
+        check_mpi(MPI_Irecv(cts_details, sizeof(fi_rma_iov), MPI_BYTE, real_rank, req.tag,
+                            phase_b, &mpi_requests[3]));
     }
 
     static void sender(struct fi_rma_iov* recv_buffer_details,
                        struct fi_rma_iov* completion_details,
-                       struct fi_rma_iov* cts_details, Request& req)
+                       struct fi_rma_iov* cts_details, Request& req, MPI_Comm phase_a,
+                       MPI_Comm phase_b)
     {
-        Print::out("(Send) Matching with:", req.peer, "and tag", req.tag);
+        int real_rank = rankLookup(req.peer, req.comm, phase_a);
+        Print::out("(Send) Matching with:", real_rank, "and tag", req.tag);
         MPI_Request* mpi_requests = req.get_match_requests(REQUESTS_TO_USE);
 
-        check_mpi(MPI_Irecv(recv_buffer_details, sizeof(fi_rma_iov), MPI_BYTE, req.peer,
-                            req.tag, req.comm, &mpi_requests[0]));
-        check_mpi(MPI_Irecv(completion_details, sizeof(fi_rma_iov), MPI_BYTE, req.peer,
-                            req.tag, req.comm, &mpi_requests[1]));
+        check_mpi(MPI_Irecv(recv_buffer_details, sizeof(fi_rma_iov), MPI_BYTE, real_rank,
+                            req.tag, phase_a, &mpi_requests[0]));
+        check_mpi(MPI_Irecv(completion_details, sizeof(fi_rma_iov), MPI_BYTE, real_rank,
+                            req.tag, phase_a, &mpi_requests[1]));
 
         Print::out("(Send) Sending: ", req.operation, cts_details->addr, cts_details->len,
                    cts_details->key);
-        check_mpi(MPI_Isend(&req.operation, sizeof(Operation), MPI_BYTE, req.peer,
-                            req.tag, req.comm, &mpi_requests[2]));
-        check_mpi(MPI_Isend(cts_details, sizeof(fi_rma_iov), MPI_BYTE, req.peer, req.tag,
-                            req.comm, &mpi_requests[3]));
+        check_mpi(MPI_Isend(&req.operation, sizeof(Operation), MPI_BYTE, real_rank,
+                            req.tag, phase_b, &mpi_requests[2]));
+        check_mpi(MPI_Isend(cts_details, sizeof(fi_rma_iov), MPI_BYTE, real_rank, req.tag,
+                            phase_b, &mpi_requests[3]));
+    }
+
+    // Figure out "base_rank"'s rank in "lookup_comm"
+    static inline int rankLookup(int base_rank, MPI_Comm base_comm, MPI_Comm lookup_comm)
+    {
+        MPI_Group base_group;
+        force_mpi(MPI_Comm_group(base_comm, &base_group));
+        MPI_Group lookup_group;
+        force_mpi(MPI_Comm_group(lookup_comm, &lookup_group));
+        int base_ranks[1]  = {base_rank};
+        int lookup_ranks[1] = {-1};
+        force_mpi(MPI_Group_translate_ranks(base_group, 1, base_ranks, lookup_group,
+                                            lookup_ranks));
+        force_mpi(MPI_Group_free(&base_group));
+        force_mpi(MPI_Group_free(&lookup_group));
+        Print::out("Started with rank:", base_rank, " ended up with", lookup_ranks[0]);
+        return lookup_ranks[0];
     }
 
     static constexpr size_t REQUESTS_TO_USE = 4;

--- a/source/core/source/queues/CXIQueue.cpp
+++ b/source/core/source/queues/CXIQueue.cpp
@@ -110,7 +110,7 @@ void LibfabricInstance::initialize_libfabric()
     check_libfabric(fi_ep_bind(ep, &(recv_ctr)->fid, FI_RECV));
 }
 
-void LibfabricInstance::initialize_peer_addresses(MPI_Comm comm_base)
+void LibfabricInstance::initialize_peer_addresses(MPI_Comm comm)
 {
     Print::out("Doing an allgather to get", comm_size, "ranks.");
     // Get our "cxi address"
@@ -122,7 +122,7 @@ void LibfabricInstance::initialize_peer_addresses(MPI_Comm comm_base)
     // All other ranks
     char* all_names = new char[_array_size * comm_size];
     memset(all_names, 0, _array_size * comm_size * sizeof(char));
-    force_mpi(MPI_Allgather(name, 4, MPI_CHAR, all_names, 4, MPI_CHAR, comm_base));
+    force_mpi(MPI_Allgather(name, 4, MPI_CHAR, all_names, 4, MPI_CHAR, comm));
 
     peers.resize(comm_size, 0);
     check_libfabric(fi_av_insert(av, all_names, comm_size, peers.data(), 0, 0));
@@ -154,6 +154,8 @@ void CXIQueue::prepare_cxi_mr_key(Request& req)
     {
         throw std::runtime_error("Operation not supported");
     }
+
+    converted_request->match(match_phase_a, match_phase_b);
 
     request_map.insert(std::make_pair(req.getID(), std::move(converted_request)));
 }

--- a/tests/multi-backend/hello_world.cpp
+++ b/tests/multi-backend/hello_world.cpp
@@ -1,9 +1,12 @@
 #include "../common/common.hpp"
 
+#include "stream-triggering.h"
+
 int main(int argc, char* argv[])
 {
     int mode;
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &mode);
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
 
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -57,14 +60,14 @@ int main(int argc, char* argv[])
     MPIS_Request my_reqs[2];
     if (0 == rank % 2)
     {
-        MPIS_Send_init(send_buf, BUFFER_SIZE, MPI_INT, 1, 10, MPI_COMM_WORLD, mem_info,
+        MPIS_Send_init(send_buf, BUFFER_SIZE, MPI_INT, 1, 0, MPI_COMM_WORLD, mem_info,
                        &my_reqs[0]);
         MPIS_Recv_init(recv_buf, BUFFER_SIZE, MPI_INT, 1, 0, MPI_COMM_WORLD, mem_info,
                        &my_reqs[1]);
     }
     else
     {
-        MPIS_Recv_init(recv_buf, BUFFER_SIZE, MPI_INT, 0, 10, MPI_COMM_WORLD, mem_info,
+        MPIS_Recv_init(recv_buf, BUFFER_SIZE, MPI_INT, 0, 0, MPI_COMM_WORLD, mem_info,
                        &my_reqs[1]);
         MPIS_Send_init(send_buf, BUFFER_SIZE, MPI_INT, 0, 0, MPI_COMM_WORLD, mem_info,
                        &my_reqs[0]);

--- a/tests/multi-backend/rsend.cpp
+++ b/tests/multi-backend/rsend.cpp
@@ -1,5 +1,7 @@
 #include "../common/common.hpp"
 
+#include "stream-triggering.h"
+
 int main(int argc, char* argv[])
 {
     int mode;

--- a/tests/multi-backend/slurm_script.sh
+++ b/tests/multi-backend/slurm_script.sh
@@ -47,7 +47,7 @@ export HSA_XNACK=1
 #export MPICH_ASYNC_PROGRESS=1
 
 # Settings related to individual tests
-TEST_NAME=rsend
+TEST_NAME=hello_world
 TIME=00:03:00
 
 cd scratch/tmp/
@@ -71,8 +71,8 @@ run_test "cxi-coarse"
 run_test "cxi-fine"
 
 export MPICH_GPU_SUPPORT_ENABLED=1
-run_test "hip"
-run_test "thread"
+#run_test "hip"
+#run_test "thread"
 unset MPICH_GPU_SUPPORT_ENABLED
 
 # While slurm has append to file, flux does not. So we have to 


### PR DESCRIPTION
Key changes:
- Added proper headers to tests in `test/multi-backend`
- Updated README with available backends and limitation to CXI backend
- Added code to create two duped communicators upon CXI Queue creation. These comms are used in the match of requests made on this backend to limit potential collisions. The communicators are freed when the queue is freed.